### PR TITLE
Scheduling: force Europe/Amsterdam tz & add indicator

### DIFF
--- a/src/Scheduling.tsx
+++ b/src/Scheduling.tsx
@@ -2,7 +2,6 @@ import { motion } from "framer-motion";
 import { sectionVariants, getAnimations } from "./animations";
 import type { AnimTypes } from "./animations";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import { useMatchQuery, useScheduleQuery } from "./state/huis";
 import logo from "./static/img/logo.png";
 import clsx from "clsx";
@@ -15,8 +14,6 @@ interface SchedulingScreenProps {
 }
 
 export function SchedulingScreen({ from, to }: SchedulingScreenProps) {
-  dayjs.extend(utc);
-
   // treat this component as self (to) and other as from
   const anims: AnimTypes = getAnimations(to, from ?? "");
 
@@ -91,8 +88,14 @@ export function SchedulingScreen({ from, to }: SchedulingScreenProps) {
                           {dayjs(match.date).fromNow()}
                         </div>
                         <div className="match-timestamp">
-                          {dayjs(match.date).utc().format("dddd HH:mm")}
-                          <span className="match-timestamp-tz">UTC</span>
+                          {dayjs(match.date)
+                            .tz("Europe/Amsterdam")
+                            .format("dddd HH:mm")}
+                          <span className="match-timestamp-tz">
+                            {dayjs(match.date)
+                              .tz("Europe/Amsterdam")
+                              .format("z")}
+                          </span>
                         </div>
                       </div>
                     </div>
@@ -152,8 +155,14 @@ export function SchedulingScreen({ from, to }: SchedulingScreenProps) {
                           {dayjs(match.date).fromNow()}
                         </div>
                         <div className="match-timestamp">
-                          {dayjs(match.date).utc().format("dddd HH:mm")}
-                          <span className="match-timestamp-tz">UTC</span>
+                          {dayjs(match.date)
+                            .tz("Europe/Amsterdam")
+                            .format("dddd HH:mm")}
+                          <span className="match-timestamp-tz">
+                            {dayjs(match.date)
+                              .tz("Europe/Amsterdam")
+                              .format("z")}
+                          </span>
                         </div>
                       </div>
                     </div>

--- a/src/Scheduling.tsx
+++ b/src/Scheduling.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import { sectionVariants, getAnimations } from "./animations";
 import type { AnimTypes } from "./animations";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { useMatchQuery, useScheduleQuery } from "./state/huis";
 import logo from "./static/img/logo.png";
 import clsx from "clsx";
@@ -14,6 +15,8 @@ interface SchedulingScreenProps {
 }
 
 export function SchedulingScreen({ from, to }: SchedulingScreenProps) {
+  dayjs.extend(utc);
+
   // treat this component as self (to) and other as from
   const anims: AnimTypes = getAnimations(to, from ?? "");
 
@@ -88,7 +91,8 @@ export function SchedulingScreen({ from, to }: SchedulingScreenProps) {
                           {dayjs(match.date).fromNow()}
                         </div>
                         <div className="match-timestamp">
-                          {dayjs(match.date).format("dddd HH:mm")}
+                          {dayjs(match.date).utc().format("dddd HH:mm")}
+                          <span className="match-timestamp-tz">UTC</span>
                         </div>
                       </div>
                     </div>
@@ -148,7 +152,8 @@ export function SchedulingScreen({ from, to }: SchedulingScreenProps) {
                           {dayjs(match.date).fromNow()}
                         </div>
                         <div className="match-timestamp">
-                          {dayjs(match.date).format("dddd HH:mm")}
+                          {dayjs(match.date).utc().format("dddd HH:mm")}
+                          <span className="match-timestamp-tz">UTC</span>
                         </div>
                       </div>
                     </div>

--- a/src/dayjs.ts
+++ b/src/dayjs.ts
@@ -1,6 +1,12 @@
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import customParseFormat from "dayjs/plugin/customParseFormat";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import advancedFormat from "dayjs/plugin/advancedFormat";
 
 dayjs.extend(relativeTime);
 dayjs.extend(customParseFormat);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(advancedFormat);

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1277,7 +1277,7 @@ p {
   font-size: 10px;
   font-family: BenderBold, Helvetica, sans-serif;
   font-weight: normal;
-  color: #919191;
+  color: #999999;
 }
 
 #schedule {

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1267,6 +1267,19 @@ p {
   margin-top: 15px;
 }
 
+.match-timestamp {
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
+}
+
+.match-timestamp-tz {
+  font-size: 10px;
+  font-family: BenderBold, Helvetica, sans-serif;
+  font-weight: normal;
+  color: #919191;
+}
+
 #schedule {
   width: 1920px;
   height: 1080px;


### PR DESCRIPTION
## Changes
- Changes match timezone from browser to Europe/Amsterdam
- Adds a timezone indicator

## Visual
### Before
<img width="188" height="111" alt="image" src="https://github.com/user-attachments/assets/0b2b1cec-f7a8-47d0-825d-c95caa6b3374" />

### After
<img width="202" height="100" alt="image" src="https://github.com/user-attachments/assets/f8dfa758-b10f-4224-aed6-98205be8f4d0" />

