### PR TITLE
add CLI keypress listeners to open URLs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -56,10 +56,49 @@ const server = serve({
 });
 
 console.log(
-  `Server listening at ${server.url}. Dashboard at ${server.url}dashboard`,
+  `Server listening on ${server.url}\nDashboard listening on ${new URL("dashboard", server.url)}`,
 );
 
-if (import.meta.hot.data.openedDashboard !== true) {
-  open(server.url.toString() + "dashboard");
-  import.meta.hot.data.openedDashboard = true;
+const overlayUrl = server.url.toString();
+const dashboardUrl = new URL("dashboard", server.url).toString();
+
+if (process.env.NODE_ENV === "production") {
+  open(dashboardUrl);
 }
+
+process.stdin.setRawMode(true);
+process.stdin.setEncoding("utf8");
+process.stdin.removeAllListeners();
+process.stdin.on("readable", () => {
+  for (const chunk of process.stdin.read() as string) {
+    switch (chunk) {
+      case "o":
+        console.log("Opening overlay in browser...");
+        open(overlayUrl);
+        break;
+      case "d":
+        console.log("Opening dashboard in browser...");
+        open(dashboardUrl);
+        break;
+      case "b":
+        console.log("Opening both overlay and dashboard in browser...");
+        open(overlayUrl);
+        open(dashboardUrl);
+        break;
+      case "q":
+      case "\u0003": // Ctrl-C
+        console.log("Quitting...");
+        process.exit();
+    }
+  }
+});
+
+console.log(
+  `
+  Press [o] to open the overlay
+  Press [d] to open the dashboard
+  Press [b] to open both
+
+  Press [q] to quit
+`,
+);


### PR DESCRIPTION
dashboard only auto-opens in the production build now

added some keypress listeners for in the terminal to open the dashboard and/or overlay in the browser, for development and production (thought it could be useful for both)