### PR TITLE
define NODE_ENV as a build time constant

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,19 +1,39 @@
+import { $ } from "bun";
 import bunPluginTailwind from "bun-plugin-tailwind";
 
-const targets = {
+const targets: Record<string, Bun.Build.Target> = {
   windows: "bun-windows-x64",
   macos: "bun-darwin-x64",
   linux: "bun-linux-x64",
-} satisfies Record<string, Bun.Build.Target>;
+};
+
+const version = await $`git describe --tags --always`.text();
+const buildTime = new Date().toISOString();
+const gitCommit = await $`git rev-parse HEAD`.text();
+
+const define = (config: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(config).map(([key, value]) => [key, JSON.stringify(value)]),
+  );
 
 for (const [platform, target] of Object.entries(targets)) {
   await Bun.build({
-    plugins: [bunPluginTailwind],
+    // plugins: [bunPluginTailwind],
     entrypoints: ["./src/server.ts"],
     outdir: "./dist",
+    env: "PUBLIC_*",
+    define: define({
+      BUILD_VERSION: version.trim(),
+      BUILD_TIME: buildTime,
+      GIT_COMMIT: gitCommit.trim(),
+    }),
     compile: {
       target,
       outfile: `ndc-overlay-${platform}`,
     },
+    minify: true,
+    sourcemap: true,
   });
 }
+
+console.log("Build successful :3");

--- a/build.ts
+++ b/build.ts
@@ -23,6 +23,7 @@ for (const [platform, target] of Object.entries(targets)) {
     outdir: "./dist",
     env: "PUBLIC_*",
     define: define({
+      "process.env.NODE_ENV": "production",
       BUILD_VERSION: version.trim(),
       BUILD_TIME: buildTime,
       GIT_COMMIT: gitCommit.trim(),


### PR DESCRIPTION
doesn't look like Bun sets this when compiling as a single file executable, or even inlines `process.env.NODE_ENV` as "development", even if inlining is completely turned off. Idk what's up with that but this works

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #24 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #26 
<!-- GitButler Footer Boundary Bottom -->

